### PR TITLE
Feature/recruit list page UI

### DIFF
--- a/lib/core/presentation/components/search_bar.dart
+++ b/lib/core/presentation/components/search_bar.dart
@@ -1,0 +1,31 @@
+import 'package:dongsoop/ui/color_styles.dart';
+import 'package:flutter/material.dart';
+
+class SearchBarComponent extends StatelessWidget {
+  const SearchBarComponent({super.key});
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      height: 44,
+      child: (TextField(
+        decoration: InputDecoration(
+            filled: true,
+            fillColor: ColorStyles.gray1,
+            contentPadding: EdgeInsets.all(8),
+            border: InputBorder.none,
+            enabledBorder: OutlineInputBorder(
+                borderSide: BorderSide(color: Colors.transparent),
+                borderRadius: BorderRadius.circular(8)),
+            focusedBorder: OutlineInputBorder(
+                borderSide: BorderSide(color: Colors.transparent),
+                borderRadius: BorderRadius.circular(8)),
+            suffixIcon: Icon(
+              Icons.search,
+              size: 24.00,
+              color: ColorStyles.gray3,
+            )),
+      )),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:dongsoop/presentation/board/recruit/list/recruit_list_page_screen.dart';
 import 'package:dongsoop/presentation/home/home_page_screen.dart';
 import 'package:dongsoop/presentation/my_page/my_page_screen.dart';
 import 'package:flutter/material.dart';
@@ -16,7 +17,8 @@ class MyApp extends StatelessWidget {
       routes: {
         // 특정 페이지 확인용
         '/home': (context) => HomePageScreen(),
-        '/mypage': (context) => MyPageScreen()
+        '/mypage': (context) => MyPageScreen(),
+        '/recruit': (context) => RecruitListPageScreen(),
       },
     );
   }

--- a/lib/presentation/board/common/board_tap_section.dart
+++ b/lib/presentation/board/common/board_tap_section.dart
@@ -1,0 +1,118 @@
+import 'package:dongsoop/core/presentation/components/search_bar.dart';
+import 'package:dongsoop/ui/color_styles.dart';
+import 'package:dongsoop/ui/text_styles.dart';
+import 'package:flutter/material.dart';
+
+class BoardTabSection extends StatelessWidget {
+  final int selectedCategoryIndex; // 모집 / 장터 탭 인덱스
+  final int selectedSubTabIndex; // 하단 텍스트 탭 인덱스
+  final List<String> subTabs; // ['튜터링', '스터디', '프로젝트'] or ['판매', '구매']
+  final void Function(int) onCategorySelected;
+  final void Function(int) onSubTabSelected;
+
+  const BoardTabSection({
+    super.key,
+    required this.selectedCategoryIndex,
+    required this.selectedSubTabIndex,
+    required this.subTabs,
+    required this.onCategorySelected,
+    required this.onSubTabSelected,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(top: 36),
+          child: Row(
+            children: [
+              _buildCategoryButton('모집', 0),
+              const SizedBox(width: 16),
+              _buildCategoryButton('장터', 1),
+            ],
+          ),
+        ),
+        const Padding(
+          padding: EdgeInsets.symmetric(vertical: 16),
+          child: SearchBarComponent(),
+        ),
+        Padding(
+          padding: const EdgeInsets.only(bottom: 12),
+          child: Row(
+            children: List.generate(subTabs.length, (index) {
+              return Row(
+                children: [
+                  GestureDetector(
+                    onTap: () => onSubTabSelected(index),
+                    child: _buildUnderlineTab(
+                      subTabs[index],
+                      selectedSubTabIndex == index,
+                    ),
+                  ),
+                  if (index != subTabs.length - 1) const SizedBox(width: 24),
+                ],
+              );
+            }),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildCategoryButton(String label, int index) {
+    final isSelected = selectedCategoryIndex == index;
+    return Container(
+      width: 44,
+      alignment: Alignment.center,
+      child: TextButton(
+        onPressed: () => onCategorySelected(index),
+        style: TextButton.styleFrom(
+          padding: EdgeInsets.zero,
+          overlayColor:
+              MaterialStateColor.resolveWith((_) => Colors.transparent),
+        ),
+        child: Text(
+          label,
+          style: isSelected
+              ? TextStyles.titleTextBold.copyWith(color: ColorStyles.primary100)
+              : TextStyles.titleTextRegular.copyWith(color: ColorStyles.gray4),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildUnderlineTab(String label, bool isSelected) {
+    return Container(
+      constraints: const BoxConstraints(minWidth: 44, minHeight: 44),
+      alignment: Alignment.bottomCenter,
+      child: Stack(
+        alignment: Alignment.bottomCenter,
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(bottom: 2),
+            child: Text(
+              label,
+              style: isSelected
+                  ? TextStyles.largeTextBold
+                      .copyWith(color: ColorStyles.primary100)
+                  : TextStyles.largeTextRegular
+                      .copyWith(color: ColorStyles.gray4),
+            ),
+          ),
+          if (isSelected)
+            Positioned(
+              bottom: 0,
+              left: 0,
+              right: 0,
+              child: Container(
+                height: 1,
+                color: ColorStyles.primary100,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/board/common/board_write_button.dart
+++ b/lib/presentation/board/common/board_write_button.dart
@@ -1,0 +1,32 @@
+import 'package:dongsoop/ui/color_styles.dart';
+import 'package:flutter/material.dart';
+
+class WriteButton extends StatelessWidget {
+  final VoidCallback onPressed;
+
+  const WriteButton({
+    super.key,
+    required this.onPressed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 16),
+      child: SizedBox(
+        width: 56,
+        height: 56,
+        child: FloatingActionButton(
+          backgroundColor: ColorStyles.primary100,
+          onPressed: onPressed,
+          shape: const CircleBorder(),
+          child: Icon(
+            Icons.add,
+            color: ColorStyles.white,
+            size: 30.00,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/board/recruit/list/recruit_list_page_screen.dart
+++ b/lib/presentation/board/recruit/list/recruit_list_page_screen.dart
@@ -1,0 +1,169 @@
+import 'package:dongsoop/presentation/board/common/board_tap_section.dart';
+import 'package:dongsoop/presentation/board/common/board_write_button.dart';
+import 'package:dongsoop/presentation/board/recruit/temp/temp_project_data.dart';
+import 'package:dongsoop/presentation/board/recruit/temp/temp_study_data.dart';
+import 'package:dongsoop/presentation/board/recruit/temp/temp_tag_utils.dart';
+import 'package:dongsoop/presentation/board/recruit/temp/temp_tutor_data.dart';
+import 'package:dongsoop/ui/color_styles.dart';
+import 'package:dongsoop/ui/text_styles.dart';
+import 'package:flutter/material.dart';
+
+class RecruitPageScreen extends StatefulWidget {
+  const RecruitPageScreen({super.key});
+
+  @override
+  State<RecruitPageScreen> createState() => _State();
+}
+
+class _State extends State<RecruitPageScreen> {
+  int selectedIndex = 0; // 모집(0), 장터(1)
+  int selectedRecruitIndex = 0; // 튜터링(0), 스터디(1), 프로젝트(2)
+
+  @override
+  Widget build(BuildContext context) {
+    List<Map<String, dynamic>> recruitData;
+    switch (selectedRecruitIndex) {
+      case 1:
+        recruitData = studyList;
+        break;
+      case 2:
+        recruitData = projectList;
+        break;
+      default:
+        recruitData = tutorList;
+        break;
+    }
+
+    return SafeArea(
+      child: Scaffold(
+        backgroundColor: ColorStyles.white,
+        floatingActionButton: WriteButton(
+            onPressed: () => Navigator.pushNamed(context, '/recruit/write')),
+        body: selectedIndex == 0
+            ? ListView.builder(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                itemCount: recruitData.length + 1,
+                itemBuilder: (context, index) {
+                  if (index == 0) {
+                    return BoardTabSection(
+                      selectedCategoryIndex: selectedIndex,
+                      selectedSubTabIndex: selectedRecruitIndex,
+                      subTabs: ['튜터링', '스터디', '프로젝트'],
+                      onCategorySelected: (index) {
+                        setState(() {
+                          selectedIndex = index;
+                        });
+                      },
+                      onSubTabSelected: (index) {
+                        setState(() {
+                          selectedRecruitIndex = index;
+                        });
+                      },
+                    );
+                  }
+
+                  final recruit = recruitData[index - 1];
+                  final isLastItem = index - 1 == recruitData.length - 1;
+                  return RecruitListItem(
+                    recruit: recruit,
+                    isLastItem: isLastItem,
+                    onTap: () {
+                      Navigator.pushNamed(
+                        context,
+                        '/recruit/detail',
+                        arguments: {'id': recruit['id']},
+                      );
+                    },
+                  );
+                },
+              )
+            : Center(
+                child: Text(
+                  '장터 페이지',
+                  style: TextStyles.largeTextRegular,
+                ),
+              ),
+      ),
+    );
+  }
+}
+
+class RecruitListItem extends StatelessWidget {
+  final Map<String, dynamic> recruit;
+  final VoidCallback onTap;
+  final bool isLastItem;
+
+  const RecruitListItem({
+    super.key,
+    required this.recruit,
+    required this.onTap,
+    required this.isLastItem,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 24),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Row(
+                      children: [
+                        Text(
+                          recruit['recruit_state'],
+                          style: TextStyles.smallTextBold
+                              .copyWith(color: ColorStyles.black),
+                        ),
+                        SizedBox(width: 8),
+                        Text(
+                          recruit['recruit_people'],
+                          style: TextStyles.smallTextRegular
+                              .copyWith(color: ColorStyles.gray4),
+                        ),
+                      ],
+                    ),
+                    Text(
+                      recruit['recruit_date'],
+                      style: TextStyles.smallTextRegular
+                          .copyWith(color: ColorStyles.gray4),
+                    ),
+                  ],
+                ),
+                SizedBox(height: 16),
+                Text(
+                  recruit['title'],
+                  style: TextStyles.largeTextBold
+                      .copyWith(color: ColorStyles.black),
+                ),
+                Text(
+                  recruit['description'],
+                  style: TextStyles.smallTextRegular
+                      .copyWith(color: ColorStyles.black),
+                ),
+                SizedBox(height: 24),
+                Row(
+                  children: recruit['tags']
+                      .map<Widget>((tag) => buildTag(tag))
+                      .toList(),
+                ),
+              ],
+            ),
+          ),
+          if (!isLastItem)
+            Divider(
+              color: ColorStyles.gray2,
+              height: 1,
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/board/recruit/list/recruit_list_page_screen.dart
+++ b/lib/presentation/board/recruit/list/recruit_list_page_screen.dart
@@ -8,14 +8,14 @@ import 'package:dongsoop/ui/color_styles.dart';
 import 'package:dongsoop/ui/text_styles.dart';
 import 'package:flutter/material.dart';
 
-class RecruitPageScreen extends StatefulWidget {
-  const RecruitPageScreen({super.key});
+class RecruitListPageScreen extends StatefulWidget {
+  const RecruitListPageScreen({super.key});
 
   @override
-  State<RecruitPageScreen> createState() => _State();
+  State<RecruitListPageScreen> createState() => _State();
 }
 
-class _State extends State<RecruitPageScreen> {
+class _State extends State<RecruitListPageScreen> {
   int selectedIndex = 0; // 모집(0), 장터(1)
   int selectedRecruitIndex = 0; // 튜터링(0), 스터디(1), 프로젝트(2)
 

--- a/lib/presentation/board/recruit/temp/temp_project_data.dart
+++ b/lib/presentation/board/recruit/temp/temp_project_data.dart
@@ -1,0 +1,37 @@
+// 코드가 너무 길어져서 임시로 만들어둔 파일
+// 백엔드와 연동시 삭제 예정
+
+final List<Map<String, dynamic>> projectList = [
+  {
+    "recruit_state": "모집중",
+    "recruit_people": "12명이 지원했어요",
+    "recruit_date": "3.4. ~ 3. 11.",
+    "title": "컴공 프로젝트",
+    "description": "[프로젝트 모집합니다] 교내 프로젝트 인원 모집합니다..",
+    "tags": ["컴퓨터소프트웨어공학과", "프로젝트"]
+  },
+  {
+    "recruit_state": "모집중",
+    "recruit_people": "0명이 지원했어요",
+    "recruit_date": "2. 14. ~ 2. 21.",
+    "title": "웹 프로젝트",
+    "description": "팀원 잘 만나고 싶어요",
+    "tags": ["컴퓨터소프트웨어공학과", "프로젝트", "백엔드"]
+  },
+  {
+    "recruit_state": "모집중",
+    "recruit_people": "3명이 지원했어요",
+    "recruit_date": "3. 10. ~ 3. 19.",
+    "title": "앱 프로젝트 같이 할사람",
+    "description": "앱 프로젝트 같이 해요",
+    "tags": ["컴퓨터소프트웨어공학과", "앱", "풀스택"]
+  },
+  {
+    "recruit_state": "모집중",
+    "recruit_people": "12명이 지원했어요",
+    "recruit_date": "3. 14. ~ 3. 21.",
+    "title": "웹 프로젝트",
+    "description": "팀원 잘 만나고 싶어요",
+    "tags": ["컴퓨터소프트웨어공학과", "프로젝트", "프론트엔드"]
+  },
+];

--- a/lib/presentation/board/recruit/temp/temp_study_data.dart
+++ b/lib/presentation/board/recruit/temp/temp_study_data.dart
@@ -1,0 +1,53 @@
+// 코드가 너무 길어져서 임시로 만들어둔 파일
+// 백엔드와 연동시 삭제 예정
+
+final List<Map<String, dynamic>> studyList = [
+  {
+    "recruit_state": "모집중",
+    "recruit_people": "12명이 지원했어요",
+    "recruit_date": "3.4. ~ 3.11.",
+    "title": "Figma 스터디",
+    "description": "figma 아예 다뤄본 적 없는 사람만",
+    "tags": ["컴퓨터소프트웨어공학과", "Figma"]
+  },
+  {
+    "recruit_state": "모집중",
+    "recruit_people": "3명이 지원했어요",
+    "recruit_date": "3.2. ~ 3.9.",
+    "title": "SQLD 자격증 취득 스터디",
+    "description": "SQLD 하루 벼락치기 스터디원 모집합니다.",
+    "tags": ["컴퓨터소프트웨어공학과", "자격증", "SQLD"]
+  },
+  {
+    "recruit_state": "모집중",
+    "recruit_people": "0명이 지원했어요",
+    "recruit_date": "2.20. ~ 2.26.",
+    "title": "컴활 2급",
+    "description": "컴퓨터 활용 능력 2급 같이 공부하실 분",
+    "tags": ["컴퓨터소프트웨어공학과", "자격증", "컴활2급"]
+  },
+  {
+    "recruit_state": "모집중",
+    "recruit_people": "12명이 지원했어요",
+    "recruit_date": "2.6 ~ 2.11.",
+    "title": "리눅스 마스터",
+    "description": "리눅스 마스터 전직",
+    "tags": ["컴퓨터소프트웨어공학과", "자격증", "리눅스"]
+  },
+  {
+    "recruit_state": "모집중",
+    "recruit_people": "0명이 지원했어요",
+    "recruit_date": "3.2. ~ 3.9.",
+    "title": "SQLD 자격증 취득 스터디",
+    "description": "SQLD 하루 벼락치기 스터디원 모집합니다.",
+    "tags": ["컴퓨터소프트웨어공학과", "자격증", "SQLD"]
+  },
+  {
+    "recruit_state": "모집중",
+    "recruit_people": "3명이 지원했어요",
+    "recruit_date": "3.7. ~ 3.11.",
+    "title": "Figma 스터디",
+    "description": "figma 아예 다뤄본 적 없는 사람만",
+    "tags": ["컴퓨터소프트웨어공학과", "Figma"]
+  },
+];

--- a/lib/presentation/board/recruit/temp/temp_tag_utils.dart
+++ b/lib/presentation/board/recruit/temp/temp_tag_utils.dart
@@ -1,0 +1,53 @@
+import 'package:dongsoop/ui/color_styles.dart';
+import 'package:dongsoop/ui/text_styles.dart';
+import 'package:flutter/material.dart';
+
+// _buildTag 함수
+Widget buildTag(String tag) {
+  Color backColor;
+  TextStyle textStyle;
+
+  if (tag == "컴퓨터소프트웨어공학과") {
+    backColor = ColorStyles.primary5;
+    textStyle =
+        TextStyles.smallTextBold.copyWith(color: ColorStyles.primary100);
+  } else if (tag == "DB" ||
+      tag == "JAVA" ||
+      tag == "Linux" ||
+      tag == "자격증" ||
+      tag == "Figma" ||
+      tag == "프로젝트" ||
+      tag == "앱") {
+    backColor = ColorStyles.labelColorRed10;
+    textStyle =
+        TextStyles.smallTextBold.copyWith(color: ColorStyles.labelColorRed100);
+  } else if (tag == "김희숙교수님" ||
+      tag == "장용미교수님" ||
+      tag == "전종로교수님" ||
+      tag == "백엔드" ||
+      tag == "풀스택" ||
+      tag == "프론트엔드" ||
+      tag == "리눅스" ||
+      tag == "SQLD" ||
+      tag == "컴활2급") {
+    backColor = ColorStyles.labelColorYellow10;
+    textStyle = TextStyles.smallTextBold
+        .copyWith(color: ColorStyles.labelColorYellow100);
+  } else {
+    backColor = ColorStyles.gray2;
+    textStyle = TextStyles.smallTextBold.copyWith(color: ColorStyles.gray4);
+  }
+
+  return Container(
+    margin: EdgeInsets.only(right: 8),
+    padding: EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+    decoration: BoxDecoration(
+      color: backColor,
+      borderRadius: BorderRadius.circular(32),
+    ),
+    child: Text(
+      tag,
+      style: textStyle,
+    ),
+  );
+}

--- a/lib/presentation/board/recruit/temp/temp_tutor_data.dart
+++ b/lib/presentation/board/recruit/temp/temp_tutor_data.dart
@@ -1,0 +1,53 @@
+// 코드가 너무 길어져서 임시로 만들어둔 파일
+// 백엔드와 연동시 삭제 예정
+
+final List<Map<String, dynamic>> tutorList = [
+  {
+    "recruit_state": "모집중",
+    "recruit_people": "12명이 지원했어요",
+    "recruit_date": "3. 4. ~ 3. 11.",
+    "title": "DB 프로그래밍",
+    "description": "[DB 프로그래밍 튜터링 모집합니다] 교내 튜터링 인원 모집합니다..",
+    "tags": ["컴퓨터소프트웨어공학과", "DB", "김희숙교수님"]
+  },
+  {
+    "recruit_state": "모집중",
+    "recruit_people": "0명이 지원했어요",
+    "recruit_date": "2. 14. ~ 2. 21.",
+    "title": "웹 프로젝트 실습",
+    "description": "팀원 잘 만나는 게 A+ 받는 방법이다",
+    "tags": ["컴퓨터소프트웨어공학과", "JAVA", "장용미교수님"]
+  },
+  {
+    "recruit_state": "모집중",
+    "recruit_people": "3명이 지원했어요",
+    "recruit_date": "3. 10. ~ 3. 19.",
+    "title": "운영체제 실습",
+    "description": "리눅스를 배워보아요",
+    "tags": ["컴퓨터소프트웨어공학과", "Linux", "전종로교수님"]
+  },
+  {
+    "recruit_state": "모집중",
+    "recruit_people": "12명이 지원했어요",
+    "recruit_date": "3. 14. ~ 3. 21.",
+    "title": "DB 프로그래밍",
+    "description": "[DB 프로그래밍 튜터링 모집합니다] 교내 튜터링 인원 모집합니다..",
+    "tags": ["컴퓨터소프트웨어공학과", "DB", "김희숙교수님"]
+  },
+  {
+    "recruit_state": "모집중",
+    "recruit_people": "0명이 지원했어요",
+    "recruit_date": "3. 7. ~ 3. 15.",
+    "title": "웹 프로젝트 실습",
+    "description": "팀원 잘 만나는 게 A+ 받는 방법이다",
+    "tags": ["컴퓨터소프트웨어공학과", "JAVA", "장용미교수님"]
+  },
+  {
+    "recruit_state": "모집중",
+    "recruit_people": "3명이 지원했어요",
+    "recruit_date": "3. 2. ~ 3. 9.",
+    "title": "운영체제 실습",
+    "description": "리눅스를 배워보아요",
+    "tags": ["컴퓨터소프트웨어공학과", "Linux", "전종로교수님"]
+  },
+];


### PR DESCRIPTION
### 작업 내용
- recruitListPage
  - 공용 UI search_bar 제작 
  - UI 확인용 dummy 데이터 파일 생성(추후 백엔드와 연동시 삭제 예정)
  - recruitListPage, marketListPage에 공통으로 필요한 버튼 UI 제작
  - recruitListPage, marketListPage에 공통으로 필요한 탭바 UI 제작

### 폴더 구조
- market과 recruit 둘 다 게시판 기능에 해당하므로 board 디렉토리 밑에 각각 market와 recruit 폴더를 만들어 제작 예정
- 각 폴더에는 write, list, detail 세 가지 화면을 기준으로 파일을 나눌 예정
  - 코드 분량 많아질 경우 widgets/ 디렉토리로 세부 UI 분리 예정
  
이렇게 진행해도 괜찮으실까요??