### PR TITLE
Refactor/use custom header in webview

### DIFF
--- a/lib/presentation/web_view/cafeteria_web_view_page_screen.dart
+++ b/lib/presentation/web_view/cafeteria_web_view_page_screen.dart
@@ -1,3 +1,4 @@
+import 'package:dongsoop/core/presentation/components/detail_header.dart';
 import 'package:flutter/material.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
@@ -25,7 +26,7 @@ class _CafeteriaWebViewPageScreenState
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('학식 배너 웹뷰')),
+      appBar: DetailHeader(),
       body: WebViewWidget(controller: controller),
     );
   }

--- a/lib/presentation/web_view/library_banner_web_view_screen.dart
+++ b/lib/presentation/web_view/library_banner_web_view_screen.dart
@@ -1,3 +1,4 @@
+import 'package:dongsoop/core/presentation/components/detail_header.dart';
 import 'package:flutter/material.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
@@ -26,7 +27,7 @@ class _LibraryBannerWebViewState extends State<LibraryBannerWebViewScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('도서관 배너 웹뷰')),
+      appBar: DetailHeader(),
       body: WebViewWidget(controller: controller),
     );
   }

--- a/lib/presentation/web_view/notice_web_view_screen.dart
+++ b/lib/presentation/web_view/notice_web_view_screen.dart
@@ -1,3 +1,4 @@
+import 'package:dongsoop/core/presentation/components/detail_header.dart';
 import 'package:flutter/material.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
@@ -43,7 +44,7 @@ class _NoticeWebViewScreenState extends State<NoticeWebViewScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('공지 상세보기')),
+      appBar: DetailHeader(),
       body: _controller == null
           ? const Center(child: Text('잘못된 URL입니다.'))
           : WebViewWidget(controller: _controller!),


### PR DESCRIPTION
### 반영 브랜치
> main < use-custom-header-in-webview

### 작업 내용
- 공지, 식단, 도서관 웹뷰 헤더 커스텀 헤더로 변경