### PR TITLE
Bugfix/recruit detail contact state

### DIFF
--- a/lib/presentation/board/recruit/detail/recruit_detail_page_screen.dart
+++ b/lib/presentation/board/recruit/detail/recruit_detail_page_screen.dart
@@ -90,22 +90,25 @@ class RecruitDetailPageScreen extends ConsumerWidget {
           final viewType = detail.viewType;
           final isAuthor = viewType == 'OWNER';
           final isGuest = viewType == 'GUEST';
+          final bool isRecruiting = (status ?? '모집 중') == '모집 중';
 
-          String buttonLabel;
-          bool isEnabled = true;
+          String buttonLabel = '지원하기';
+          bool isPrimaryButtonEnabled = isRecruiting;
 
           if (isAuthor) {
             buttonLabel = '지원자 확인';
+            isPrimaryButtonEnabled = true;
           } else if (viewType == 'MEMBER' && detail.isAlreadyApplied) {
             buttonLabel = '지원 완료';
-            isEnabled = false;
-          } else {
-            buttonLabel = '지원하기';
+            isPrimaryButtonEnabled = false;
           }
+
+          final bool canInquire = isRecruiting;
 
           return RecruitBottomButton(
             label: buttonLabel,
-            isEnabled: isEnabled,
+            isApplyEnabled: isPrimaryButtonEnabled,
+            isInquiryEnabled: canInquire,
             onPressed: () async {
               if (isAuthor) {
                 onTapApplicantList();

--- a/lib/presentation/board/recruit/detail/widget/botton_button.dart
+++ b/lib/presentation/board/recruit/detail/widget/botton_button.dart
@@ -40,6 +40,7 @@ class RecruitBottomButton extends StatelessWidget {
                 style: IconButton.styleFrom(
                   foregroundColor: ColorStyles.gray4,
                   disabledForegroundColor: ColorStyles.gray4,
+                  highlightColor: Colors.transparent,
                 ),
                 icon: const Icon(Icons.chat_bubble_outline,
                     size: 24, color: ColorStyles.gray4),

--- a/lib/presentation/board/recruit/detail/widget/botton_button.dart
+++ b/lib/presentation/board/recruit/detail/widget/botton_button.dart
@@ -3,17 +3,19 @@ import 'package:dongsoop/ui/text_styles.dart';
 import 'package:flutter/material.dart';
 
 class RecruitBottomButton extends StatelessWidget {
-  final VoidCallback? onPressed;
   final String label;
-  final bool isEnabled;
+  final VoidCallback? onPressed;
   final VoidCallback? onIconPressed;
+  final bool isApplyEnabled;
+  final bool isInquiryEnabled;
 
   const RecruitBottomButton({
     super.key,
     required this.label,
     this.onPressed,
-    this.isEnabled = true,
     this.onIconPressed,
+    this.isApplyEnabled = true,
+    this.isInquiryEnabled = true,
   });
 
   @override
@@ -32,9 +34,13 @@ class RecruitBottomButton extends StatelessWidget {
                 borderRadius: BorderRadius.circular(8),
               ),
               child: IconButton(
-                onPressed: isEnabled
+                onPressed: isInquiryEnabled
                     ? onIconPressed
                     : null,
+                style: IconButton.styleFrom(
+                  foregroundColor: ColorStyles.gray4,
+                  disabledForegroundColor: ColorStyles.gray4,
+                ),
                 icon: const Icon(Icons.chat_bubble_outline,
                     size: 24, color: ColorStyles.gray4),
               ),
@@ -44,13 +50,13 @@ class RecruitBottomButton extends StatelessWidget {
               child: SizedBox(
                 height: 48,
                 child: ElevatedButton(
-                  onPressed: isEnabled ? onPressed : null,
+                  onPressed: isApplyEnabled ? onPressed : null,
                   style: ElevatedButton.styleFrom(
                     backgroundColor:
-                        isEnabled ? ColorStyles.primary100 : ColorStyles.gray1,
+                        isApplyEnabled ? ColorStyles.primary100 : ColorStyles.gray1,
                     textStyle: TextStyles.largeTextBold,
                     foregroundColor:
-                        isEnabled ? ColorStyles.white : ColorStyles.gray3,
+                        isApplyEnabled ? ColorStyles.white : ColorStyles.gray3,
                     elevation: 0,
                     shape: RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(8),


### PR DESCRIPTION
### 반영 브랜치
> develop < bugfix/recruit-detail-contact-state

### 작업 내용
- 모집 게시글 상세 화면에서 '문의하기' 아이콘 버튼과 '지원하기' 버튼의 활성화 조건을 분리
- '문의하기' 버튼은 모집 상태가 '모집 중'일 때만 활성화되도록 수정