### PR TITLE
fix: allow device token registration without notification permission

### DIFF
--- a/lib/data/device_token/repository/device_token_repository_impl.dart
+++ b/lib/data/device_token/repository/device_token_repository_impl.dart
@@ -21,14 +21,15 @@ class DeviceTokenRepositoryImpl implements DeviceTokenRepository {
 
   @override
   Future<FailureType?> registerDeviceToken(DeviceTokenRequest request) async {
-    final allowed = await _fcm.requestPermissionIfNeeded();
-    if (!allowed) {
-      return FailureType.permissionDenied;
+    bool allowed = false;
+    try {
+      allowed = await _fcm.requestPermissionIfNeeded();
+    } catch (_) {
     }
 
     try {
       await _remote.registerDeviceToken(request);
-      return null;
+      return allowed ? null : FailureType.permissionDenied;
     } catch (_) {
       return FailureType.registerFailed;
     }


### PR DESCRIPTION
### 반영 브랜치
> develop < fix/device-token-register-on-denied

### 작업 내용
- 권한 여부와 관계없이 항상 서버에 디바이스 토큰을 등록하도록 수정