### PR TITLE
fix: prevent duplicate requests by rendering only active tab in PageView

### DIFF
--- a/lib/presentation/board/market/list/market_list_item.dart
+++ b/lib/presentation/board/market/list/market_list_item.dart
@@ -3,12 +3,14 @@ import 'package:dongsoop/domain/board/market/enum/market_type.dart';
 import 'package:dongsoop/presentation/board/market/list/view_model/market_list_view_model.dart';
 import 'package:dongsoop/presentation/board/market/price_formatter.dart';
 import 'package:dongsoop/presentation/board/utils/date_time_formatter.dart';
+import 'package:dongsoop/presentation/board/utils/scroll_listener.dart';
 import 'package:dongsoop/ui/color_styles.dart';
 import 'package:dongsoop/ui/text_styles.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-class MarketItemListSection extends ConsumerWidget {
+class MarketItemListSection extends HookConsumerWidget {
   final MarketType marketType;
   final void Function(int id, MarketType type) onTapMarketDetail;
   final ScrollController scrollController;
@@ -22,9 +24,18 @@ class MarketItemListSection extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final state = ref.watch(marketListViewModelProvider(type: marketType));
-    final viewModel =
-        ref.read(marketListViewModelProvider(type: marketType).notifier);
+    final provider = marketListViewModelProvider(type: marketType);
+    final state = ref.watch(provider);
+    final viewModel = ref.read(provider.notifier);
+
+    useEffect(() {
+      return setupScrollListener(
+        scrollController: scrollController,
+        getState: () => ref.read(provider),
+        canFetchMore: (s) => !s.isLoading && s.hasMore,
+        fetchMore: () => viewModel.fetchNext(),
+      );
+    }, [marketType, scrollController]);
 
     if (state.error != null) {
       return Padding(
@@ -36,6 +47,12 @@ class MarketItemListSection extends ConsumerWidget {
             textAlign: TextAlign.center,
           ),
         ),
+      );
+    }
+
+    if (state.isLoading && state.items.isEmpty) {
+      return const Center(
+        child: CircularProgressIndicator(color: ColorStyles.primaryColor),
       );
     }
 
@@ -53,8 +70,20 @@ class MarketItemListSection extends ConsumerWidget {
         controller: scrollController,
         padding: const EdgeInsets.symmetric(horizontal: 16),
         physics: const AlwaysScrollableScrollPhysics(),
-        itemCount: state.items.length,
+        itemCount: state.items.length + ((state.hasMore && state.isLoading) ? 1 : 0),
         itemBuilder: (context, index) {
+          final showLoading =
+              index == state.items.length && state.hasMore && state.isLoading;
+
+          if (showLoading) {
+            return const Padding(
+              padding: EdgeInsets.symmetric(vertical: 24),
+              child: Center(
+                child: CircularProgressIndicator(color: ColorStyles.primaryColor),
+              ),
+            );
+          }
+
           final market = state.items[index];
           final isLast = index == state.items.length - 1;
 


### PR DESCRIPTION
### 반영 브랜치
> develop < fix/duplicate-fetch-on-tab-switch

### 작업 내용
- 모집 ↔ 장터 탭 전환 시, 이웃 탭까지 불필요하게 API 요청이 나가던 문제를 해결