### PR TITLE
fix/chat login dialog

### DIFF
--- a/lib/presentation/chat/chat_screen.dart
+++ b/lib/presentation/chat/chat_screen.dart
@@ -102,9 +102,11 @@ class ChatScreen extends HookConsumerWidget {
         });
       }
       return () {
-        Future.microtask(() {
-          viewModel.closeChatList();
-        });
+        if (user != null) {
+          Future.microtask(() {
+            viewModel.closeChatList();
+          });
+        }
       };
     }, [user]);
 

--- a/lib/presentation/chat/chat_view_model.dart
+++ b/lib/presentation/chat/chat_view_model.dart
@@ -7,11 +7,9 @@ import 'package:dongsoop/domain/chat/use_case/chat/disconnect_chat_list_use_case
 import 'package:dongsoop/domain/chat/use_case/chat/get_chat_rooms_use_case.dart';
 import 'package:dongsoop/domain/chat/use_case/stream/subscribe_chat_list_use_case.dart';
 import 'package:dongsoop/presentation/chat/chat_state.dart';
-import 'package:dongsoop/providers/chat_providers.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 class ChatViewModel extends StateNotifier<ChatState> {
-  final Ref _ref;
   final GetChatRoomsUseCase _loadChatRoomsUseCase;
   final GetBlindDateOpenUseCase _getBlindDateOpenUseCase;
 
@@ -20,7 +18,6 @@ class ChatViewModel extends StateNotifier<ChatState> {
   final SubscribeChatListUseCase _subscribeChatListUseCase;
 
   ChatViewModel(
-    this._ref,
     this._loadChatRoomsUseCase,
     this._getBlindDateOpenUseCase,
     this._connectChatListUseCase,

--- a/lib/providers/chat_providers.dart
+++ b/lib/providers/chat_providers.dart
@@ -261,7 +261,7 @@ final chatViewModelProvider = StateNotifierProvider<ChatViewModel, ChatState>((r
   final disconnectChatListUseCase = ref.watch(disconnectChatListUseCaseProvider);
   final subscribeChatListUseCase = ref.watch(subscribeChatListUseCaseProvider);
 
-  return ChatViewModel(ref, loadChatRoomsUseCase, getBlindDateOpenUseCase, connectChatListUseCase, disconnectChatListUseCase, subscribeChatListUseCase);
+  return ChatViewModel(loadChatRoomsUseCase, getBlindDateOpenUseCase, connectChatListUseCase, disconnectChatListUseCase, subscribeChatListUseCase);
 });
 
 final chatDetailViewModelProvider = StateNotifierProvider<ChatDetailViewModel, ChatDetailState>((ref) {


### PR DESCRIPTION
### 반영 브랜치
> develop < fix/chat-login-dialog

### 작업 내용
- 비로그인 상태에서 채팅 다이얼로그를 통해 로그인 할 경우 생기는 오류 해결
- 사용하지 않는 프로바이더 삭제