### PR TITLE
refactor: Apple Provider를 App Attest only로 변경

### DIFF
--- a/.github/workflows/android-deploy.yml
+++ b/.github/workflows/android-deploy.yml
@@ -2,7 +2,7 @@ name: Google Play Console Deploy - Android
 
 on:
   push:
-    branches: [ main ]
+    branches: [ fix/app-check-error ]
 
 jobs:
   build-android:


### PR DESCRIPTION
### 반영 브랜치
> develop < fix/app-check-error

### 작업 내용
- device check fall back 제거
  - app attest 최소 지원버전이 13.0이라 device check fall back 필요 x 