### PR TITLE
Fix/app check error ios

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -5,6 +5,16 @@ import flutter_local_notifications
 import FirebaseAppCheck
 import FirebaseCore
 
+class MyAppCheckProviderFactory: NSObject, AppCheckProviderFactory {
+  func createProvider(with app: FirebaseApp) -> AppCheckProvider? {
+    if #available(iOS 14.0, *) {
+      return AppAttestProvider(app: app)
+    } else {
+      return DeviceCheckProvider(app: app)
+    }
+  }
+}
+
 @main
 @objc class AppDelegate: FlutterAppDelegate {
   private var pushChannel: FlutterMethodChannel?
@@ -15,6 +25,7 @@ import FirebaseCore
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
+    AppCheck.setAppCheckProviderFactory(MyAppCheckProviderFactory())
     FirebaseApp.configure()
 
     FlutterLocalNotificationsPlugin.setPluginRegistrantCallback { registry in

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -31,7 +31,7 @@ Future<void> main() async {
 
   await FirebaseAppCheck.instance.activate(
     androidProvider: AndroidProvider.playIntegrity,
-    appleProvider: AppleProvider.appAttest,
+    appleProvider: AppleProvider.appAttestWithDeviceCheckFallback,
   );
   await FirebaseAppCheck.instance.setTokenAutoRefreshEnabled(true);
 

--- a/macos/Flutter/ephemeral/Flutter-Generated.xcconfig
+++ b/macos/Flutter/ephemeral/Flutter-Generated.xcconfig
@@ -1,6 +1,6 @@
 // This is a generated file; do not edit or check into version control.
-FLUTTER_ROOT=/Users/seungwon-woo/development/flutter
-FLUTTER_APPLICATION_PATH=/Users/seungwon-woo/dongsoop
+FLUTTER_ROOT=/Users/seungbhin/Downloads/flutter
+FLUTTER_APPLICATION_PATH=/Users/seungbhin/dongsoop
 COCOAPODS_PARALLEL_CODE_SIGN=true
 FLUTTER_BUILD_DIR=build
 FLUTTER_BUILD_NAME=1.2.0

--- a/macos/Flutter/ephemeral/flutter_export_environment.sh
+++ b/macos/Flutter/ephemeral/flutter_export_environment.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # This is a generated file; do not edit or check into version control.
-export "FLUTTER_ROOT=/Users/seungwon-woo/development/flutter"
-export "FLUTTER_APPLICATION_PATH=/Users/seungwon-woo/dongsoop"
+export "FLUTTER_ROOT=/Users/seungbhin/Downloads/flutter"
+export "FLUTTER_APPLICATION_PATH=/Users/seungbhin/dongsoop"
 export "COCOAPODS_PARALLEL_CODE_SIGN=true"
 export "FLUTTER_BUILD_DIR=build"
 export "FLUTTER_BUILD_NAME=1.2.0"


### PR DESCRIPTION
### 반영 브랜치
> develop < fix/app-check-error-ios

### 작업 내용
- `FirebaseApp.configure()` 호출 전에 `AppCheckProviderFactory`를 등록하도록 변경